### PR TITLE
Implement auto reset on server and client

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,5 +2,5 @@
 	"width": 1000,
 	"height": 1000,
 	"bombs": 222222,
-	"etag": "10/09/2021 Chrome fix no logging"
+	"etag": "04/26/2023 Auto Reset"
 }

--- a/html/minesweeper.js
+++ b/html/minesweeper.js
@@ -584,6 +584,8 @@ class Gui {
 		this.board.assign_bombs_with_indices(board_data["Bombs"])
 		this.minimap = new Minimap(this)
 		this.minimap.count_bombs(board_data["Bombs"])
+		this.reveal_index = 0;
+		this.flag_index = 0;
 	} 
 
 	load_image(image_path) {
@@ -900,27 +902,7 @@ class Gui {
 	}
 
 	reset() {
-		this.canvas = document.getElementById("game");
-		var width = parseInt(document.getElementById("width").value, 10);
-		var height = parseInt(document.getElementById("height").value, 10);
-		var num_bombs = parseInt(document.getElementById("num_bombs").value, 10);
-		var tile_size = parseInt(document.getElementById("tile_size").value, 10);
-		this.board = new Board(width, height, num_bombs);
-		var old_tile_size = this.tile_size;
-		this.tile_size = tile_size;
-		this.resize();
-		this.first_click = true;
-		this.current_x = 0;
-		this.current_y = 0;
-		this.window_width = this.window_width;;
-		this.window_height = this.window_height;
-
-		if (old_tile_size != this.tile_size) {
-			gui.load_images().then(() => {gui.render() })
-		}
-		else{
-			this.render_region();
-		}
+		
 	}
 
 	apply() {
@@ -1010,6 +992,11 @@ function start_listening() {
 	function recieve_data(event) {
 		var message = new DataView(event.data)
 		num_players = message.getInt32(0)
+		// num_players less than 0 means this is a reset event
+		if (num_players < 0) {
+			gui.load_board().then(() => gui.render_region())
+			return
+		}
 		num_reveals = message.getInt32(4)
 		num_flags = message.getInt32(8)
 		gui.player_positions.length = num_players * 2

--- a/html/minesweeper.js
+++ b/html/minesweeper.js
@@ -901,10 +901,6 @@ class Gui {
 		this.render_region();
 	}
 
-	reset() {
-		
-	}
-
 	apply() {
 		var new_tile_size = parseInt(document.getElementById("tile_size").value, 10);
 		this.resize(new_tile_size);
@@ -1033,11 +1029,6 @@ function start_listening() {
 gui.load_board_and_images().then(() => { start_listening() })
 
 
-
-
-function reset() {
-	gui.reset();
-}
 
 function apply() {
 	gui.apply()

--- a/main.go
+++ b/main.go
@@ -388,13 +388,10 @@ func auto_reset_on_completion() {
 		<- ticker.C
 		if (check_complete(board)) {
 			init_board()
+			log.Println("Starting new game: ", game_id)
 		}
 	}
 }
-
-//TODO: On the fly resets
-//Make board initialization method that can be called during runtime to reset the board state
-//Will need to reset the 
 
 func main() {
 	load_config(&config)


### PR DESCRIPTION
Make it so that I don't have to manually restart the server every time the board is completed.
The server will check every 10 seconds for whether the board has been completed.
If it is, it will update the game on the server. If a player is out of sync, they will be sent a special reset message which tells the client to re-fetch the board and remake the minimap.